### PR TITLE
Use Random::Secure

### DIFF
--- a/src/cipher/cipher.cr
+++ b/src/cipher/cipher.cr
@@ -40,12 +40,12 @@ class OpenSSL::Cipher
   end
 
   def random_key
-    iv = SecureRandom.random_bytes key_len
+    key = Random::Secure.random_bytes key_len
     self.key = key
   end
 
   def random_iv
-    iv = SecureRandom.random_bytes iv_len
+    iv = Random::Secure.random_bytes iv_len
     self.iv = iv
   end
 


### PR DESCRIPTION
Hello!

In Crystal 0.24, `SecureRandom` was relocated to `Random::Secure`. This causes calls to `OpenSSL::Cipher#random_key` and `#random_iv` to fail to compile.

I can add a test if you like; if so, please advise what you would like that test to look like.